### PR TITLE
[TASK] Add BUNDLED WITH to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,3 +354,6 @@ DEPENDENCIES
   valle
   web-console
   yard
+
+BUNDLED WITH
+   1.10.2


### PR DESCRIPTION
With recent versions of Bundler, a bundle install writes a BUNDLED WITH
line to Gemfile.lock. This commits adds it so that a bundle install does
not change the Gemfile.lock anymore.